### PR TITLE
Fix payment pending race

### DIFF
--- a/app/controllers/Controller.scala
+++ b/app/controllers/Controller.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.pattern.after
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.qrcode.QRCodeWriter
 import config.OpReturnBotAppConfig
@@ -69,6 +70,17 @@ class Controller @Inject() (
   val onChainDAO: OnChainPaymentDAO = OnChainPaymentDAO()
   val nip5DAO: Nip5DAO = Nip5DAO()
   val zapDAO: ZapDAO = ZapDAO()
+
+  private val paymentStatusRetryDelay = 750.millis
+
+  private def waitForTxId(
+      rHash: Sha256Digest): Future[Option[DoubleSha256DigestBE]] = {
+    after(paymentStatusRetryDelay, system.scheduler) {
+      invoiceDAO
+        .findOpReturnRequestByRHash(rHash)
+        .map(_.flatMap(_._2.txIdOpt))
+    }
+  }
 
   // The URL to the request.  You can call this directly from the template, but it
   // can be more convenient to leave the template completely stateless i.e. all
@@ -488,30 +500,33 @@ class Controller @Inject() (
 
           opReturnDAO.safeDatabase
             .run(action)
-            .map {
+            .flatMap {
               case None =>
-                BadRequest("Invoice not from OP_RETURN Bot")
+                Future.successful(BadRequest("Invoice not from OP_RETURN Bot"))
               case Some((onChainOpt, invoiceDb, requestDb)) =>
-                requestDb.txIdOpt match {
-                  case Some(txId) =>
-                    Redirect(routes.Controller.success(txId.hex))
-                  case None =>
-                    if (invoiceDb.paid) {
-                      Ok(views.html.pending())
-                    } else {
-                      onChainOpt match {
-                        case None =>
-                          Ok(
-                            views.html.showInvoice(requestDb.getMessage,
-                                                   invoiceDb.invoice))
-                        case Some(onChain) =>
-                          val unified = createUnifiedAddr(onChain, invoiceDb)
-                          Ok(
-                            views.html.showUnified(requestDb.getMessage,
-                                                   invoiceDb.rHash.hex,
-                                                   unified))
-                      }
+                PaymentStatus(invoiceDb.paid, requestDb.txIdOpt) match {
+                  case PaymentStatus.Complete(_) =>
+                    Future.successful(
+                      Redirect(routes.Controller.success(hash.hex)))
+                  case PaymentStatus.Pending =>
+                    waitForTxId(hash).map {
+                      case Some(_) =>
+                        Redirect(routes.Controller.success(hash.hex))
+                      case None => Ok(views.html.pending())
                     }
+                  case PaymentStatus.Unpaid =>
+                    Future.successful(onChainOpt match {
+                      case None =>
+                        Ok(
+                          views.html.showInvoice(requestDb.getMessage,
+                                                 invoiceDb.invoice))
+                      case Some(onChain) =>
+                        val unified = createUnifiedAddr(onChain, invoiceDb)
+                        Ok(
+                          views.html.showUnified(requestDb.getMessage,
+                                                 invoiceDb.rHash.hex,
+                                                 unified))
+                    })
                 }
             }
       }
@@ -533,26 +548,31 @@ class Controller @Inject() (
             BadRequest(views.html
               .index(recentTransactions.toSeq, opReturnRequestForm, postUrl)))
         case Success(rHash) =>
-          invoiceDAO.findOpReturnRequestByRHash(rHash).map {
+          invoiceDAO.findOpReturnRequestByRHash(rHash).flatMap {
             case None =>
-              BadRequest(views.html
-                .index(recentTransactions.toSeq, opReturnRequestForm, postUrl))
+              Future.successful(BadRequest(views.html
+                .index(recentTransactions.toSeq, opReturnRequestForm, postUrl)))
             case Some((invoiceDb, requestDb)) =>
-              requestDb.txIdOpt match {
-                case Some(txId) =>
-                  Ok(
-                    views.html.success(txId,
-                                       requestDb.messageBytes.length > 80))
-                case None =>
-                  if (invoiceDb.paid) {
-                    Ok(views.html.pending())
-                  } else {
+              PaymentStatus(invoiceDb.paid, requestDb.txIdOpt) match {
+                case PaymentStatus.Complete(txId) =>
+                  Future.successful(
+                    Ok(views.html.success(txId,
+                                          requestDb.messageBytes.length > 80)))
+                case PaymentStatus.Pending =>
+                  waitForTxId(rHash).map {
+                    case Some(txId) =>
+                      Ok(
+                        views.html.success(txId,
+                                           requestDb.messageBytes.length > 80))
+                    case None => Ok(views.html.pending())
+                  }
+                case PaymentStatus.Unpaid =>
+                  Future.successful(
                     BadRequest(
                       views.html
                         .index(recentTransactions.toSeq,
                                opReturnRequestForm,
-                               postUrl))
-                  }
+                               postUrl)))
               }
           }
       }

--- a/app/controllers/PaymentStatus.scala
+++ b/app/controllers/PaymentStatus.scala
@@ -1,0 +1,21 @@
+package controllers
+
+import org.bitcoins.crypto.DoubleSha256DigestBE
+
+sealed private[controllers] trait PaymentStatus
+
+private[controllers] object PaymentStatus {
+  case object Unpaid extends PaymentStatus
+  case object Pending extends PaymentStatus
+  case class Complete(txId: DoubleSha256DigestBE) extends PaymentStatus
+
+  def apply(
+      invoicePaid: Boolean,
+      txIdOpt: Option[DoubleSha256DigestBE]): PaymentStatus = {
+    txIdOpt match {
+      case Some(txId)          => Complete(txId)
+      case None if invoicePaid => Pending
+      case None                => Unpaid
+    }
+  }
+}

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,10 +1,13 @@
-@(title: String)(content: Html)
+@(title: String, refreshSeconds: Option[Int] = None)(content: Html)
 
 <!DOCTYPE html>
 
 <html lang="en">
     <head>
         <title>@title</title>
+        @for(seconds <- refreshSeconds) {
+            <meta http-equiv="refresh" content="@seconds">
+        }
         <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
         <link href="@{
             "https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css"

--- a/app/views/pending.scala.html
+++ b/app/views/pending.scala.html
@@ -1,11 +1,9 @@
-@()(implicit request: MessagesRequestHeader)
+@()
 
-@main("Success") {
+@main("Payment received", Some(2)) {
 
-<h1>Success!</h1>
+<h1>Payment received</h1>
 
-<p> Your invoice was successfully paid, sadly, OP_RETURN Bot is being overwhelmed with requests and is unable to process
-    your transaction at this time. </p>
-<p>Your transaction will be sent shortly, you do not need to take any other action</p>
-<p>You can refresh this page to see if the transaction was broadcast</p>
+<p>Your payment succeeded. The broadcast of your transaction is in progress.</p>
+<p>This page refreshes automatically until the transaction ID is available.</p>
 }

--- a/test/controllers/PaymentStatusTest.scala
+++ b/test/controllers/PaymentStatusTest.scala
@@ -1,0 +1,42 @@
+package controllers
+
+import org.bitcoins.crypto.DoubleSha256DigestBE
+import org.scalatestplus.play.PlaySpec
+
+class PaymentStatusTest extends PlaySpec {
+
+  private val txId = DoubleSha256DigestBE("00" * 32)
+
+  "PaymentStatus" must {
+
+    "keep an unpaid request on the invoice page" in {
+      PaymentStatus(invoicePaid = false, txIdOpt = None) mustBe
+        PaymentStatus.Unpaid
+    }
+
+    "send a paid request with a transaction ID to success" in {
+      PaymentStatus(invoicePaid = true, txIdOpt = Some(txId)) mustBe
+        PaymentStatus.Complete(txId)
+    }
+
+    "advance a pending request after its transaction ID exists" in {
+      PaymentStatus(invoicePaid = true, txIdOpt = None) mustBe
+        PaymentStatus.Pending
+      PaymentStatus(invoicePaid = true, txIdOpt = Some(txId)) mustBe
+        PaymentStatus.Complete(txId)
+    }
+  }
+
+  "The pending page" must {
+
+    "refresh automatically without showing a failure" in {
+      val html = views.html.pending().body
+
+      html must include("http-equiv=\"refresh\"")
+      html must include("content=\"2\"")
+      html must include("Your payment succeeded")
+      html must not include "overwhelmed"
+      html must not include "unable to process"
+    }
+  }
+}


### PR DESCRIPTION
The paid state can appear before the transaction ID write completes. Wait once for the ID and refresh the pending page so users reach the success page without manual action.